### PR TITLE
[Feat] 홈 대시보드 & 바텀시트 조회 & 추천 행동 선택

### DIFF
--- a/src/main/java/com/slowflow/slowflowbackend/action/controller/FillActionController.java
+++ b/src/main/java/com/slowflow/slowflowbackend/action/controller/FillActionController.java
@@ -1,0 +1,38 @@
+package com.slowflow.slowflowbackend.action.controller;
+
+import com.slowflow.slowflowbackend.action.dto.FillActionBottomSheetResponse;
+import com.slowflow.slowflowbackend.action.dto.SelectFillActionResponse;
+import com.slowflow.slowflowbackend.action.service.FillActionService;
+import com.slowflow.slowflowbackend.global.response.ApiResponse;
+import com.slowflow.slowflowbackend.member.model.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/fill-actions")
+public class FillActionController {
+
+    private final FillActionService fillActionService;
+
+    // 바텀 시트 조회
+    @GetMapping("/bottom-sheet")
+    public ResponseEntity<ApiResponse<FillActionBottomSheetResponse>> getBottomSheet(Authentication authentication) {
+        Member member = (Member) authentication.getPrincipal();
+        FillActionBottomSheetResponse res = fillActionService.getBottomSheet(member);
+        return ResponseEntity.ok(ApiResponse.ok("바텀시트 추천 행동 조회 성공", res));
+    }
+
+    // 추천 행동 선택
+    @PostMapping("/{fillActionId}/select")
+    public ResponseEntity<ApiResponse<SelectFillActionResponse>> select(
+            Authentication authentication,
+            @PathVariable Long fillActionId
+    ) {
+        Member member = (Member) authentication.getPrincipal();
+        SelectFillActionResponse res = fillActionService.selectFillAction(member, fillActionId);
+        return ResponseEntity.ok(ApiResponse.ok("추천 행동 선택 성공", res));
+    }
+}

--- a/src/main/java/com/slowflow/slowflowbackend/action/dto/FillActionBottomSheetResponse.java
+++ b/src/main/java/com/slowflow/slowflowbackend/action/dto/FillActionBottomSheetResponse.java
@@ -1,0 +1,17 @@
+package com.slowflow.slowflowbackend.action.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class FillActionBottomSheetResponse {
+
+    private LocalDate date;          // 오늘 날짜
+    private int currentScore;         // 오늘 totalScore
+    private boolean recommendable;    // currentScore < 0 이면 true
+    private List<FillActionDto> items;
+}

--- a/src/main/java/com/slowflow/slowflowbackend/action/dto/FillActionDto.java
+++ b/src/main/java/com/slowflow/slowflowbackend/action/dto/FillActionDto.java
@@ -1,0 +1,14 @@
+package com.slowflow.slowflowbackend.action.dto;
+
+import com.slowflow.slowflowbackend.rule.model.RuleCategory;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FillActionDto {
+    private Long id;
+    private RuleCategory category;
+    private String behavior;
+    private int score;
+}

--- a/src/main/java/com/slowflow/slowflowbackend/action/dto/SelectFillActionResponse.java
+++ b/src/main/java/com/slowflow/slowflowbackend/action/dto/SelectFillActionResponse.java
@@ -1,0 +1,15 @@
+package com.slowflow.slowflowbackend.action.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class SelectFillActionResponse {
+
+    private LocalDate date;
+    private int appliedScore;     // 실제 반영된 점수(캡 때문에 줄어들 수 있음)
+    private int updatedTotalScore;
+}

--- a/src/main/java/com/slowflow/slowflowbackend/action/repository/FillActionRepository.java
+++ b/src/main/java/com/slowflow/slowflowbackend/action/repository/FillActionRepository.java
@@ -1,0 +1,12 @@
+package com.slowflow.slowflowbackend.action.repository;
+
+import com.slowflow.slowflowbackend.action.model.FillAction;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface FillActionRepository extends JpaRepository<FillAction, Long> {
+    @Query(value = "SELECT * FROM fill_action WHERE score > 0 ORDER BY random() LIMIT 3", nativeQuery = true)
+    List<FillAction> findRandomTop3Positive();
+}

--- a/src/main/java/com/slowflow/slowflowbackend/action/repository/UserActionRepository.java
+++ b/src/main/java/com/slowflow/slowflowbackend/action/repository/UserActionRepository.java
@@ -13,4 +13,6 @@ public interface UserActionRepository extends JpaRepository<UserAction, Long> {
             LocalDate start,
             LocalDate end
     );
+
+    boolean existsByMemberIdAndDate(Long memberId, LocalDate date);
 }

--- a/src/main/java/com/slowflow/slowflowbackend/action/service/FillActionService.java
+++ b/src/main/java/com/slowflow/slowflowbackend/action/service/FillActionService.java
@@ -1,0 +1,201 @@
+package com.slowflow.slowflowbackend.action.service;
+
+import com.slowflow.slowflowbackend.action.dto.*;
+import com.slowflow.slowflowbackend.action.model.FillAction;
+import com.slowflow.slowflowbackend.action.model.UserAction;
+import com.slowflow.slowflowbackend.action.repository.FillActionRepository;
+import com.slowflow.slowflowbackend.action.repository.UserActionRepository;
+import com.slowflow.slowflowbackend.global.exception.BaseException;
+import com.slowflow.slowflowbackend.global.exception.ErrorCode;
+import com.slowflow.slowflowbackend.member.model.Member;
+import com.slowflow.slowflowbackend.rule.model.RuleCategory;
+import com.slowflow.slowflowbackend.score.model.DailyScore;
+import com.slowflow.slowflowbackend.score.model.DailyState;
+import com.slowflow.slowflowbackend.score.repository.DailyScoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FillActionService {
+
+    private final FillActionRepository fillActionRepository;
+    private final DailyScoreRepository dailyScoreRepository;
+    private final UserActionRepository userActionRepository;
+
+    // ===== CAP 상수 =====
+    private static final int DIET_POS_CAP = 100;
+    private static final int DIET_NEG_CAP = 160;
+
+    private static final int EX_POS_CAP = 120;
+    private static final int EX_NEG_CAP = 40;
+
+    private static final int SLEEP_POS_CAP = 80;
+    private static final int SLEEP_NEG_CAP = 120;
+
+    private static final int TOTAL_MIN = -300;
+    private static final int TOTAL_MAX = 300;
+
+    // ----------------------------
+    // 1) 바텀 시트 조회
+    // ----------------------------
+    public FillActionBottomSheetResponse getBottomSheet(Member member) {
+        LocalDate today = LocalDate.now();
+
+        DailyScore todayScore = dailyScoreRepository
+                .findByMemberIdAndDate(member.getId(), today)
+                .orElse(null);
+
+        int currentTotal = (todayScore == null) ? 0 : todayScore.getTotalScore();
+        boolean recommendable = currentTotal < 0;
+
+        List<FillActionDto> items = List.of();
+        if (recommendable) {
+            items = fillActionRepository.findRandomTop3Positive()
+                    .stream()
+                    .map(f -> new FillActionDto(f.getId(), f.getCategory(), f.getBehavior(), f.getScore()))
+                    .toList();
+        }
+
+        return new FillActionBottomSheetResponse(today, currentTotal, recommendable, items);
+    }
+
+    // ----------------------------
+    // 2) 추천 행동 선택 → 오늘 행동 추가 + 점수 반영
+    // ----------------------------
+    public SelectFillActionResponse selectFillAction(Member member, Long fillActionId) {
+        LocalDate today = LocalDate.now();
+
+        DailyScore ds = dailyScoreRepository
+                .findByMemberIdAndDate(member.getId(), today)
+                .orElseGet(() -> dailyScoreRepository.save(
+                        DailyScore.builder()
+                                .member(member)
+                                .date(today)
+                                .dietPositive(0).dietNegative(0)
+                                .exercisePositive(0).exerciseNegative(0)
+                                .sleepPositive(0).sleepNegative(0)
+                                .totalScore(0)
+                                .state(DailyState.NONE)
+                                .build()
+                ));
+
+        // 요구사항: 현재 점수가 음수일 때만 추천 행동 선택 가능
+        if (ds.getTotalScore() >= 0) {
+            throw new BaseException(ErrorCode.FILL_ACTION_NOT_AVAILABLE); // 새 에러코드 추가 권장
+        }
+
+        FillAction fillAction = fillActionRepository.findById(fillActionId)
+                .orElseThrow(() -> new BaseException(ErrorCode.FILL_ACTION_NOT_FOUND)); // 새 에러코드 추가 권장
+
+        int applied = applyToDailyScore(member, ds, fillAction.getCategory(), fillAction.getScore());
+        dailyScoreRepository.save(ds);
+
+        // UserAction 기록 추가
+        UserAction ua = UserAction.builder()
+                .member(member)
+                .category(fillAction.getCategory())
+                .rawText("[추천 행동] " + fillAction.getBehavior())
+                .parsedJson(null)
+                .score(applied)
+                .reason("바텀시트 추천 행동 선택")
+                .date(today)
+                .createdAt(LocalDateTime.now())
+                .rule(null) // 추천 행동은 rule 연결이 필요 없으면 null
+                .build();
+
+        userActionRepository.save(ua);
+
+        return new SelectFillActionResponse(today, applied, ds.getTotalScore());
+    }
+
+    // ===== 내부 로직 =====
+
+    private int applyToDailyScore(Member member, DailyScore ds, RuleCategory category, int score) {
+        if (score == 0) return 0;
+
+        if (category == RuleCategory.DIET) {
+            return applyCategory(ds, score, DIET_POS_CAP, DIET_NEG_CAP,
+                    ds.getDietPositive(), ds.getDietNegative(),
+                    ds::updateDietPositive, ds::updateDietNegative, member);
+        }
+
+        if (category == RuleCategory.EXERCISE) {
+            return applyCategory(ds, score, EX_POS_CAP, EX_NEG_CAP,
+                    ds.getExercisePositive(), ds.getExerciseNegative(),
+                    ds::updateExercisePositive, ds::updateExerciseNegative, member);
+        }
+
+        if (category == RuleCategory.SLEEP) {
+            return applyCategory(ds, score, SLEEP_POS_CAP, SLEEP_NEG_CAP,
+                    ds.getSleepPositive(), ds.getSleepNegative(),
+                    ds::updateSleepPositive, ds::updateSleepNegative, member);
+        }
+
+        // 3개 카테고리만 허용
+        throw new BaseException(ErrorCode.INVALID_CATEGORY);
+    }
+
+    @FunctionalInterface
+    private interface IntSetter { void set(int v); }
+
+    private int applyCategory(
+            DailyScore ds,
+            int score,
+            int posCap,
+            int negCap,
+            int currentPos,
+            int currentNeg,
+            IntSetter setPos,
+            IntSetter setNeg,
+            Member member
+    ) {
+        int applied;
+
+        if (score > 0) {
+            int remain = Math.max(0, posCap - currentPos);
+            applied = Math.min(score, remain);
+            if (applied <= 0) throw new BaseException(ErrorCode.DAILY_CAP_REACHED);
+            setPos.set(currentPos + applied);
+        } else {
+            int abs = Math.abs(score);
+            int remain = Math.max(0, negCap - currentNeg);
+            int add = Math.min(abs, remain);
+            if (add <= 0) throw new BaseException(ErrorCode.DAILY_CAP_REACHED);
+            setNeg.set(currentNeg + add);
+            applied = -add;
+        }
+
+        // total 재계산 + clamp(-300~300)
+        int posSum = safe(ds.getDietPositive()) + safe(ds.getExercisePositive()) + safe(ds.getSleepPositive());
+        int negSum = safe(ds.getDietNegative()) + safe(ds.getExerciseNegative()) + safe(ds.getSleepNegative());
+
+        int total = posSum - negSum;
+        total = clamp(total, TOTAL_MIN, TOTAL_MAX);
+        ds.updateTotalScore(total);
+
+        // state 업데이트
+        ds.updateState(calcState(member, total));
+
+        return applied;
+    }
+
+    private static int safe(Integer v) { return v == null ? 0 : v; }
+
+    private static int clamp(int v, int min, int max) {
+        return Math.max(min, Math.min(max, v));
+    }
+
+    private static DailyState calcState(Member member, int totalScore) {
+        int goal = member.getGoalScore();
+
+        if (goal > 0 && totalScore >= goal) return DailyState.GOAL_REACHED;
+        if (totalScore > 0) return DailyState.POSITIVE;
+        if (totalScore < 0) return DailyState.NEGATIVE;
+        return DailyState.NEUTRAL;
+    }
+}

--- a/src/main/java/com/slowflow/slowflowbackend/feedback/model/Feedback.java
+++ b/src/main/java/com/slowflow/slowflowbackend/feedback/model/Feedback.java
@@ -17,7 +17,7 @@ public class Feedback {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private DailyState state;
+    private FeedbackType type;
 
     @Column(nullable = false, columnDefinition = "TEXT")
     private String message;

--- a/src/main/java/com/slowflow/slowflowbackend/feedback/model/FeedbackType.java
+++ b/src/main/java/com/slowflow/slowflowbackend/feedback/model/FeedbackType.java
@@ -1,0 +1,9 @@
+package com.slowflow.slowflowbackend.feedback.model;
+
+public enum FeedbackType {
+    START,        // 기록 없음
+    ZERO,         // 0점(기록은 있는데 상쇄됨)
+    POSITIVE,     // 점수 > 0
+    NEGATIVE,     // 점수 < 0
+    GOAL_REACHED  // 점수 >= 목표
+}

--- a/src/main/java/com/slowflow/slowflowbackend/feedback/repository/FeedbackRepository.java
+++ b/src/main/java/com/slowflow/slowflowbackend/feedback/repository/FeedbackRepository.java
@@ -1,0 +1,20 @@
+package com.slowflow.slowflowbackend.feedback.repository;
+
+import com.slowflow.slowflowbackend.feedback.model.Feedback;
+import com.slowflow.slowflowbackend.feedback.model.FeedbackType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
+
+    // Postgres 랜덤 1개
+    @Query(value = "SELECT * FROM feedback WHERE type = :type ORDER BY RANDOM() LIMIT 1", nativeQuery = true)
+    Optional<Feedback> findRandomByType(@Param("type") String type);
+
+    default Optional<Feedback> findRandomByType(FeedbackType type) {
+        return findRandomByType(type.name());
+    }
+}

--- a/src/main/java/com/slowflow/slowflowbackend/global/exception/ErrorCode.java
+++ b/src/main/java/com/slowflow/slowflowbackend/global/exception/ErrorCode.java
@@ -25,6 +25,10 @@ public enum ErrorCode {
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "INVALID_PASSWORD", "비밀번호가 일치하지 않습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "INVALID_REFRESH_TOKEN", "리프레시 토큰이 유효하지 않습니다."),
 
+    FILL_ACTION_NOT_FOUND(HttpStatus.NOT_FOUND, "FILL_ACTION_NOT_FOUND", "추천 행동을 찾을 수 없습니다."),
+    FILL_ACTION_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "FILL_ACTION_NOT_AVAILABLE", "현재 점수가 음수일 때만 추천 행동을 선택할 수 있습니다."),
+    DAILY_CAP_REACHED(HttpStatus.CONFLICT, "DAILY_CAP_REACHED", "오늘 해당 카테고리 점수 한도(CAP)에 도달했습니다."),
+    INVALID_CATEGORY(HttpStatus.BAD_REQUEST, "INVALID_CATEGORY", "유효하지 않은 카테고리입니다."),
     // 최종 안전망
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다.");
 

--- a/src/main/java/com/slowflow/slowflowbackend/home/controller/HomeController.java
+++ b/src/main/java/com/slowflow/slowflowbackend/home/controller/HomeController.java
@@ -1,0 +1,29 @@
+package com.slowflow.slowflowbackend.home.controller;
+
+import com.slowflow.slowflowbackend.global.response.ApiResponse;
+import com.slowflow.slowflowbackend.home.dto.HomeDashboardResponse;
+import com.slowflow.slowflowbackend.home.service.HomeService;
+import com.slowflow.slowflowbackend.member.model.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/home")
+public class HomeController {
+
+    private final HomeService homeService;
+
+    // 홈 대시보드 조회
+    @GetMapping("/dashboard")
+    public ResponseEntity<ApiResponse<HomeDashboardResponse>> dashboard(Authentication authentication) {
+        Member member = (Member) authentication.getPrincipal();
+        HomeDashboardResponse result = homeService.getDashboard(member);
+
+        return ResponseEntity.ok(ApiResponse.ok("홈 대시보드 조회 성공", result));
+    }
+}

--- a/src/main/java/com/slowflow/slowflowbackend/home/dto/HomeDashboardResponse.java
+++ b/src/main/java/com/slowflow/slowflowbackend/home/dto/HomeDashboardResponse.java
@@ -1,0 +1,17 @@
+package com.slowflow.slowflowbackend.home.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class HomeDashboardResponse {
+
+    private LocalDate date;         // 오늘 날짜
+    private int currentScore;       // 오늘 점수(00:00 기준으로 새로 시작)
+    private int goalScore;          // 사용자 목표 점수
+    private int remainingToGoal;    // 목표까지 남은 점수 (0 이상)
+    private String feedback;        // 케이스별 랜덤 문구
+}

--- a/src/main/java/com/slowflow/slowflowbackend/home/service/HomeService.java
+++ b/src/main/java/com/slowflow/slowflowbackend/home/service/HomeService.java
@@ -1,0 +1,92 @@
+package com.slowflow.slowflowbackend.home.service;
+
+import com.slowflow.slowflowbackend.action.repository.UserActionRepository;
+import com.slowflow.slowflowbackend.feedback.model.Feedback;
+import com.slowflow.slowflowbackend.feedback.model.FeedbackType;
+import com.slowflow.slowflowbackend.feedback.repository.FeedbackRepository;
+import com.slowflow.slowflowbackend.home.dto.HomeDashboardResponse;
+import com.slowflow.slowflowbackend.member.model.Member;
+import com.slowflow.slowflowbackend.score.model.DailyScore;
+import com.slowflow.slowflowbackend.score.repository.DailyScoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HomeService {
+
+    private final DailyScoreRepository dailyScoreRepository;
+    private final UserActionRepository userActionRepository;
+    private final FeedbackRepository feedbackRepository;
+
+    public HomeDashboardResponse getDashboard(Member member) {
+        LocalDate today = LocalDate.now();
+
+        DailyScore todayScore = dailyScoreRepository
+                .findByMemberIdAndDate(member.getId(), today)
+                .orElse(null);
+
+        boolean hasTodayAction = userActionRepository.existsByMemberIdAndDate(member.getId(), today);
+
+        int currentScore = (todayScore != null) ? todayScore.getTotalScore() : 0;
+
+        int goalScore = member.getGoalScore();
+        if (goalScore < 0) goalScore = 0;
+
+        int remaining = Math.max(goalScore - currentScore, 0);
+
+        FeedbackType type = decideFeedbackType(goalScore, currentScore, todayScore, hasTodayAction);
+
+        String feedback = feedbackRepository.findRandomByType(type)
+                .map(Feedback::getMessage)
+                .orElseGet(() -> fallbackMessage(type));
+
+        return new HomeDashboardResponse(
+                today,
+                currentScore,
+                goalScore,
+                remaining,
+                feedback
+        );
+    }
+
+    private FeedbackType decideFeedbackType(int goalScore,
+                                            int currentScore,
+                                            DailyScore todayScore,
+                                            boolean hasTodayAction) {
+
+        // 케이스 5: 목표 달성 (점수 >= 목표)
+        if (goalScore > 0 && currentScore >= goalScore) {
+            return FeedbackType.GOAL_REACHED;
+        }
+
+        // 케이스 1: 시작 전(기록 없음)
+        // - DailyScore도 없고, UserAction도 없으면 기록 없음
+        if (todayScore == null && !hasTodayAction) {
+            return FeedbackType.START;
+        }
+
+        // 케이스 2: 0점(기록은 있는데 상쇄됨)
+        if (currentScore == 0) {
+            return FeedbackType.ZERO;
+        }
+
+        // 케이스 3/4
+        return (currentScore > 0) ? FeedbackType.POSITIVE : FeedbackType.NEGATIVE;
+    }
+
+    private String fallbackMessage(FeedbackType type) {
+        // DB에 문구가 없을 때 최소 안전문구
+        return switch (type) {
+            case START -> "오늘 하루를 시작해볼까요?<br>첫 기록을 남겨보세요!";
+            case ZERO -> "딱 균형이에요!<br>조금만 더 채워보면 플러스!";
+            case POSITIVE -> "좋은 흐름이에요!<br>이 페이스로 계속 가봐요!";
+            case NEGATIVE -> "부담이 조금 더 많아요<br>작은 채움으로 회복해봐요";
+            case GOAL_REACHED -> "오늘 목표 완수!<br>내일도 이렇게 채워가봐요";
+        };
+    }
+}

--- a/src/main/java/com/slowflow/slowflowbackend/score/model/DailyScore.java
+++ b/src/main/java/com/slowflow/slowflowbackend/score/model/DailyScore.java
@@ -46,4 +46,19 @@ public class DailyScore {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    public void updateDietPositive(int v) { this.dietPositive = v; }
+    public void updateDietNegative(int v) { this.dietNegative = v; }
+
+    public void updateExercisePositive(int v) { this.exercisePositive = v; }
+    public void updateExerciseNegative(int v) { this.exerciseNegative = v; }
+
+    public void updateSleepPositive(int v) { this.sleepPositive = v; }
+    public void updateSleepNegative(int v) { this.sleepNegative = v; }
+
+    public void updateTotalScore(int v) { this.totalScore = v; }
+
+    public void updateState(DailyState state) { this.state = state; }
+
+    public void updateAiFeedback(String feedback) { this.aiFeedback = feedback; }
 }

--- a/src/main/java/com/slowflow/slowflowbackend/score/repository/DailyScoreRepository.java
+++ b/src/main/java/com/slowflow/slowflowbackend/score/repository/DailyScoreRepository.java
@@ -5,10 +5,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 public interface DailyScoreRepository extends JpaRepository<DailyScore, Long> {
 
     List<DailyScore> findByMemberIdAndDateBetween(Long memberId, LocalDate start, LocalDate end);
 
     boolean existsByMemberIdAndDateBefore(Long memberId, LocalDate date);
+
+    Optional<DailyScore> findByMemberIdAndDate(Long memberId, LocalDate date);
 }


### PR DESCRIPTION
## 📌 관련 이슈
closed #12 


## ✅ 작업 내용
<!-- 작업에 대한 설명을 적어주세요 -->
1. 홈 대시보드 조회
- START: DailyScore 없음 + UserAction 없음
- ZERO: 기록은 있는데 totalScore == 0
- POSITIVE: totalScore > 0
- NEGATIVE: totalScore < 0
- GOAL_REACHED: goalScore > 0 && totalScore >= goalScore
- 각 경우에 맞게 랜덤 문구 반환. 없으면 fallback 문구 사용

2. 바텀시트 추천
- 현재 점수가 음수인 경우 추천 행동 중 3개 랜덤으로 제공

3. 추천 행동 선택 처리
- 현재 점수가 음수인 경우에만 처리
- 선택한 FillAction의 카테고리/점수를 오늘 DailyScore에 반영
- 선택 결과를 UserAction으로 저장 

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요하다면 스크린샷을 첨부해주세요 -->


## 💬 리뷰 참고 사항
<!-- 코드 리뷰 시 유의해야 할 점을 적어주세요 -->
