### PR TITLE
[Feat] 바텀시트 조회 & 추천 행동 선택 & FastAPI 행동 채점 연동

### DIFF
--- a/src/main/java/com/slowflow/slowflowbackend/action/controller/ActionController.java
+++ b/src/main/java/com/slowflow/slowflowbackend/action/controller/ActionController.java
@@ -1,0 +1,30 @@
+package com.slowflow.slowflowbackend.action.controller;
+
+import com.slowflow.slowflowbackend.action.dto.CreateActionRequest;
+import com.slowflow.slowflowbackend.action.dto.CreateActionResponse;
+import com.slowflow.slowflowbackend.action.service.ActionService;
+import com.slowflow.slowflowbackend.global.response.ApiResponse;
+import com.slowflow.slowflowbackend.member.model.Member;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/actions")
+public class ActionController {
+
+    private final ActionService actionService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<CreateActionResponse>> create(
+            Authentication authentication,
+            @RequestBody @Valid CreateActionRequest request
+    ) {
+        Member member = (Member) authentication.getPrincipal();
+        CreateActionResponse res = actionService.createAction(member, request);
+        return ResponseEntity.ok(ApiResponse.ok("행동 입력 성공", res));
+    }
+}

--- a/src/main/java/com/slowflow/slowflowbackend/action/dto/CreateActionRequest.java
+++ b/src/main/java/com/slowflow/slowflowbackend/action/dto/CreateActionRequest.java
@@ -1,0 +1,16 @@
+package com.slowflow.slowflowbackend.action.dto;
+
+import com.slowflow.slowflowbackend.rule.model.RuleCategory;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class CreateActionRequest {
+
+    @NotNull(message = "category는 필수입니다.")
+    private RuleCategory category;
+
+    @NotBlank(message = "text는 필수입니다.")
+    private String text;
+}

--- a/src/main/java/com/slowflow/slowflowbackend/action/dto/CreateActionResponse.java
+++ b/src/main/java/com/slowflow/slowflowbackend/action/dto/CreateActionResponse.java
@@ -1,0 +1,18 @@
+package com.slowflow.slowflowbackend.action.dto;
+
+import com.slowflow.slowflowbackend.score.model.DailyState;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class CreateActionResponse {
+    private LocalDate date;
+    private int rawScore;          // FastAPI가 준 원점수
+    private int appliedScore;      // CAP 반영 후 실제 적용 점수
+    private int updatedTotalScore; // 반영 후 오늘 총점
+    private DailyState state;      // 반영 후 상태
+    private String reason;         // 채점 근거(설명)
+}

--- a/src/main/java/com/slowflow/slowflowbackend/action/service/ActionService.java
+++ b/src/main/java/com/slowflow/slowflowbackend/action/service/ActionService.java
@@ -1,0 +1,174 @@
+package com.slowflow.slowflowbackend.action.service;
+
+import com.slowflow.slowflowbackend.action.dto.CreateActionRequest;
+import com.slowflow.slowflowbackend.action.dto.CreateActionResponse;
+import com.slowflow.slowflowbackend.action.model.UserAction;
+import com.slowflow.slowflowbackend.action.repository.UserActionRepository;
+import com.slowflow.slowflowbackend.global.exception.BaseException;
+import com.slowflow.slowflowbackend.global.exception.ErrorCode;
+import com.slowflow.slowflowbackend.member.model.Member;
+import com.slowflow.slowflowbackend.rule.model.RuleCategory;
+import com.slowflow.slowflowbackend.scoring.client.ScoringClient;
+import com.slowflow.slowflowbackend.scoring.dto.ScoringRequest;
+import com.slowflow.slowflowbackend.scoring.dto.ScoringResponse;
+import com.slowflow.slowflowbackend.score.model.DailyScore;
+import com.slowflow.slowflowbackend.score.model.DailyState;
+import com.slowflow.slowflowbackend.score.repository.DailyScoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ActionService {
+
+    private final ScoringClient scoringClient;
+    private final DailyScoreRepository dailyScoreRepository;
+    private final UserActionRepository userActionRepository;
+
+    // ===== CAP 상수 =====
+    private static final int DIET_POS_CAP = 100;
+    private static final int DIET_NEG_CAP = 160;
+
+    private static final int EX_POS_CAP = 120;
+    private static final int EX_NEG_CAP = 40;
+
+    private static final int SLEEP_POS_CAP = 80;
+    private static final int SLEEP_NEG_CAP = 120;
+
+    private static final int TOTAL_MIN = -300;
+    private static final int TOTAL_MAX = 300;
+
+    public CreateActionResponse createAction(Member member, CreateActionRequest req) {
+        LocalDate today = LocalDate.now();
+
+        // 1) 오늘 DailyScore 없으면 생성
+        DailyScore ds = dailyScoreRepository.findByMemberIdAndDate(member.getId(), today)
+                .orElseGet(() -> dailyScoreRepository.save(
+                        DailyScore.builder()
+                                .member(member)
+                                .date(today)
+                                .dietPositive(0).dietNegative(0)
+                                .exercisePositive(0).exerciseNegative(0)
+                                .sleepPositive(0).sleepNegative(0)
+                                .totalScore(0)
+                                .state(DailyState.NONE)
+                                .build()
+                ));
+
+        // 2) FastAPI 채점 요청
+        ScoringResponse scored = scoringClient.score(new ScoringRequest(req.getCategory(), req.getText()));
+        int rawScore = scored.getScore();
+        String reason = scored.getReason();
+
+        // 3) Spring에서 CAP/CLAMP 반영하여 실제 적용 점수 계산 + DailyScore 업데이트
+        int appliedScore = applyToDailyScore(member, ds, req.getCategory(), rawScore);
+        dailyScoreRepository.save(ds);
+
+        // 4) UserAction 저장
+        UserAction ua = UserAction.builder()
+                .member(member)
+                .category(req.getCategory())
+                .rawText(req.getText())
+                .parsedJson(null)          // 필요하면 FastAPI 결과를 JSON으로 넣어도 됨
+                .score(appliedScore)       // “실제 적용된 점수” 저장
+                .reason(reason)
+                .date(today)
+                .createdAt(LocalDateTime.now())
+                .rule(null)                // 지금은 ScoringRule 연결 안 쓰는 구조면 null
+                .build();
+        userActionRepository.save(ua);
+
+        return new CreateActionResponse(
+                today,
+                rawScore,
+                appliedScore,
+                ds.getTotalScore(),
+                ds.getState(),
+                reason
+        );
+    }
+
+    // ===== 아래는 FillActionService와 동일한 점수 반영 로직 =====
+
+    private int applyToDailyScore(Member member, DailyScore ds, RuleCategory category, int score) {
+        if (score == 0) return 0;
+
+        if (category == RuleCategory.DIET) {
+            return applyCategory(ds, score, DIET_POS_CAP, DIET_NEG_CAP,
+                    ds.getDietPositive(), ds.getDietNegative(),
+                    ds::updateDietPositive, ds::updateDietNegative, member);
+        }
+
+        if (category == RuleCategory.EXERCISE) {
+            return applyCategory(ds, score, EX_POS_CAP, EX_NEG_CAP,
+                    ds.getExercisePositive(), ds.getExerciseNegative(),
+                    ds::updateExercisePositive, ds::updateExerciseNegative, member);
+        }
+
+        if (category == RuleCategory.SLEEP) {
+            return applyCategory(ds, score, SLEEP_POS_CAP, SLEEP_NEG_CAP,
+                    ds.getSleepPositive(), ds.getSleepNegative(),
+                    ds::updateSleepPositive, ds::updateSleepNegative, member);
+        }
+
+        throw new BaseException(ErrorCode.INVALID_INPUT, "허용되지 않은 카테고리입니다.");
+    }
+
+    @FunctionalInterface
+    private interface IntSetter { void set(int v); }
+
+    private int applyCategory(
+            DailyScore ds,
+            int score,
+            int posCap,
+            int negCap,
+            int currentPos,
+            int currentNeg,
+            IntSetter setPos,
+            IntSetter setNeg,
+            Member member
+    ) {
+        int applied;
+
+        if (score > 0) {
+            int remain = Math.max(0, posCap - currentPos);
+            applied = Math.min(score, remain);
+            if (applied <= 0) throw new BaseException(ErrorCode.DAILY_CAP_REACHED);
+            setPos.set(currentPos + applied);
+        } else {
+            int abs = Math.abs(score);
+            int remain = Math.max(0, negCap - currentNeg);
+            int add = Math.min(abs, remain);
+            if (add <= 0) throw new BaseException(ErrorCode.DAILY_CAP_REACHED);
+            setNeg.set(currentNeg + add);
+            applied = -add;
+        }
+
+        // total 재계산 + clamp(-300~300)
+        int posSum = safe(ds.getDietPositive()) + safe(ds.getExercisePositive()) + safe(ds.getSleepPositive());
+        int negSum = safe(ds.getDietNegative()) + safe(ds.getExerciseNegative()) + safe(ds.getSleepNegative());
+
+        int total = posSum - negSum;
+        total = clamp(total, TOTAL_MIN, TOTAL_MAX);
+        ds.updateTotalScore(total);
+
+        ds.updateState(calcState(member, total));
+        return applied;
+    }
+
+    private static int safe(Integer v) { return v == null ? 0 : v; }
+    private static int clamp(int v, int min, int max) { return Math.max(min, Math.min(max, v)); }
+
+    private static DailyState calcState(Member member, int totalScore) {
+        int goal = member.getGoalScore();
+        if (goal > 0 && totalScore >= goal) return DailyState.GOAL_REACHED;
+        if (totalScore > 0) return DailyState.POSITIVE;
+        if (totalScore < 0) return DailyState.NEGATIVE;
+        return DailyState.NEUTRAL;
+    }
+}

--- a/src/main/java/com/slowflow/slowflowbackend/global/config/scoring/ScoringClientConfig.java
+++ b/src/main/java/com/slowflow/slowflowbackend/global/config/scoring/ScoringClientConfig.java
@@ -1,0 +1,29 @@
+package com.slowflow.slowflowbackend.global.config.scoring;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+import java.time.Duration;
+
+@Configuration
+public class ScoringClientConfig {
+
+    @Bean
+    public RestClient scoringRestClient(
+            RestClient.Builder builder,
+            @Value("${scoring.base-url}") String baseUrl,
+            @Value("${scoring.timeout-ms:3000}") int timeoutMs
+    ) {
+        SimpleClientHttpRequestFactory rf = new SimpleClientHttpRequestFactory();
+        rf.setConnectTimeout(timeoutMs);
+        rf.setReadTimeout(timeoutMs);
+
+        return builder
+                .baseUrl(baseUrl)
+                .requestFactory(rf)
+                .build();
+    }
+}

--- a/src/main/java/com/slowflow/slowflowbackend/scoring/client/ScoringClient.java
+++ b/src/main/java/com/slowflow/slowflowbackend/scoring/client/ScoringClient.java
@@ -1,0 +1,47 @@
+package com.slowflow.slowflowbackend.scoring.client;
+
+import com.slowflow.slowflowbackend.global.exception.BaseException;
+import com.slowflow.slowflowbackend.global.exception.ErrorCode;
+import com.slowflow.slowflowbackend.scoring.dto.ScoringRequest;
+import com.slowflow.slowflowbackend.scoring.dto.ScoringResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+@Component
+@RequiredArgsConstructor
+public class ScoringClient {
+
+    private final RestClient scoringRestClient;
+
+    @Value("${scoring.internal-token:}")
+    private String internalToken;
+
+    public ScoringResponse score(ScoringRequest request) {
+        try {
+            RestClient.RequestBodySpec spec = scoringRestClient.post()
+                    .uri("/scoring")
+                    .contentType(MediaType.APPLICATION_JSON);
+
+            if (internalToken != null && !internalToken.isBlank()) {
+                spec = spec.header("X-Internal-Token", internalToken);
+            }
+
+            ScoringResponse body = spec
+                    .body(request)
+                    .retrieve()
+                    .body(ScoringResponse.class);
+
+            if (body == null) {
+                throw new BaseException(ErrorCode.INTERNAL_SERVER_ERROR, "채점 서버 응답 바디가 비었습니다.");
+            }
+            return body;
+
+        } catch (RestClientException e) {
+            throw new BaseException(ErrorCode.INTERNAL_SERVER_ERROR, "채점 서버 호출 실패: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/slowflow/slowflowbackend/scoring/dto/ScoringRequest.java
+++ b/src/main/java/com/slowflow/slowflowbackend/scoring/dto/ScoringRequest.java
@@ -1,0 +1,17 @@
+package com.slowflow.slowflowbackend.scoring.dto;
+
+import com.slowflow.slowflowbackend.rule.model.RuleCategory;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ScoringRequest {
+    private RuleCategory category;
+    private String text;
+
+    // FastAPI는 순수 채점(score, reason)만 내려주고,
+    // CAP/CLAMP/상태 반영은 Spring이 하도록 current는 안 보냄.
+}

--- a/src/main/java/com/slowflow/slowflowbackend/scoring/dto/ScoringResponse.java
+++ b/src/main/java/com/slowflow/slowflowbackend/scoring/dto/ScoringResponse.java
@@ -1,0 +1,28 @@
+package com.slowflow.slowflowbackend.scoring.dto;
+
+import com.slowflow.slowflowbackend.rule.model.RuleCategory;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class ScoringResponse {
+    private RuleCategory category;
+    private String rawText;
+
+    private int score;
+    private String reason;
+
+    private List<MatchedRule> matchedRules;
+
+    @Getter
+    @NoArgsConstructor
+    public static class MatchedRule {
+        private String ruleKey;
+        private String axis;
+        private String tag;
+        private int score;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,4 +14,9 @@ spring.jpa.properties.hibernate.format_sql=true
 # JWT
 jwt.secret=${JWT_SECRET}
 
+# FastAPI Scoring Service
+scoring.base-url=${SCORING_BASE_URL:http://127.0.0.1:8000}
+scoring.internal-token=${SCORING_INTERNAL_TOKEN:}
+scoring.timeout-ms=3000
+
 logging.level.org.springframework.security=DEBUG


### PR DESCRIPTION
## 📌 관련 이슈
closed #12 #7 


## ✅ 작업 내용
<!-- 작업에 대한 설명을 적어주세요 -->
1. 홈 대시보드 조회
- 오늘 누적 점수, 목표 점수, 남은 점수, 케이스별 피드백 문구 반환 
- 피드백 케이스 분기
  - START: 기록 없음(DailyScore 없음 + UserAction 없음)
  - ZERO: 점수 0
  - POSITIVE: 점수 > 0
  - NEGATIVE: 점수 < 0
  - GOAL_REACHED: 목표 달성(점수 >= goalScore)
2. 추천 상쇄 행동
- 현재 점수가 음수일 때 DB의 FillAction 중 랜덤 3개 반환
- 추천 행동 1개 선택 -> 오늘 한 행동에 추가 + DailyScore 갱신
3. FastAPI Scoring 연동
- ScoringClient: Spring -> FastAPI HTTP 호출 담당

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요하다면 스크린샷을 첨부해주세요 -->


## 💬 리뷰 참고 사항
<!-- 코드 리뷰 시 유의해야 할 점을 적어주세요 -->
